### PR TITLE
[public-repos] Update SDK installation docs for public registries

### DIFF
--- a/onboard_id_android.md
+++ b/onboard_id_android.md
@@ -68,7 +68,7 @@ In your app's `build.gradle` file, add the SDK dependency:
 implementation 'com.netki:netkisdk:${latest.version}'
 ```
 
-> **Note:** Replace `${latest.version}` with the current version. Check the [releases page](https://art.myverify.io/netki/libs-release-local/com/netki/netkisdk/) for available versions.
+> **Note:** Replace `${latest.version}` with the current version. Check [Maven Central](https://central.sonatype.com/artifact/com.netki/netkisdk) for available versions.
 
 ## Core Integration
 

--- a/onboard_id_ios.md
+++ b/onboard_id_ios.md
@@ -47,7 +47,7 @@ Add the following keys to your `Info.plist`:
 In your `Podfile`, add the Netki SDK:
 
 ```ruby
-pod 'NetkiSDK', :git => 'https://github.com/netkicorp/onboardid-pod.git', :tag => '{latest.version}'
+pod 'NetkiSDK', '~> {latest.version}'
 ```
 
 Then run:
@@ -56,7 +56,7 @@ Then run:
 pod install
 ```
 
-> **Note:** Replace `{latest.version}` with the current version.
+> **Note:** Replace `{latest.version}` with the current version. Check [CocoaPods](https://cocoapods.org/pods/NetkiSDK) for available versions.
 
 ### Step 2: Import the SDK
 


### PR DESCRIPTION
## Summary
- Update Android installation note to link to Maven Central
- Update iOS installation to use standard CocoaPods syntax instead of git-based pod

## Changes
- **Android**: Note now points to Maven Central for version info
- **iOS**: Changed from `pod 'NetkiSDK', :git => '...', :tag => '...'` to `pod 'NetkiSDK', '~> {latest.version}'`