### PR TITLE
docs: NetkiSDK v12 integration — drop art.myverify.io, add iOS NFC entitlements

### DIFF
--- a/onboard_id_android.md
+++ b/onboard_id_android.md
@@ -26,7 +26,7 @@ To get up and running, complete the [Installation](#installation) and [Core Inte
 
 ## Requirements
 
-- Android API level 21 (Lollipop) or higher
+- Android API level 23 (Marshmallow) or higher
 - Camera permission
 - Internet permission
 
@@ -39,26 +39,24 @@ Add the following permissions to your `AndroidManifest.xml`:
 
 ## Installation
 
-### Step 1: Add the Netki Repository
+### Step 1: Add Repositories
 
-In your project's `build.gradle` file, add the Netki maven repository:
+In your project's `settings.gradle` (or `build.gradle` if you're on an older Gradle version), make sure the following repositories are declared:
 
 ```groovy
-allprojects {
+dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
 
-        // Netki SDK repository
-        maven {
-            url "https://art.myverify.io/netki/libs-release-local/"
-        }
-
-        // Required for ML models
+        // Required for the ML liveness detection library that NetkiSDK
+        // depends on transitively.
         maven { url "https://developer.huawei.com/repo/" }
     }
 }
 ```
+
+Starting with v12.0.0, NetkiSDK is a single self-contained artifact — no additional private repositories are required.
 
 ### Step 2: Add the Dependency
 

--- a/onboard_id_ios.md
+++ b/onboard_id_ios.md
@@ -25,7 +25,7 @@ To get up and running, complete the [Installation](#installation) and [Core Inte
 
 ## Requirements
 
-- iOS 13.0 or higher
+- iOS 17.0 or higher
 - Camera permission
 - Photo Library permission
 

--- a/onboard_id_ios.md
+++ b/onboard_id_ios.md
@@ -28,6 +28,7 @@ To get up and running, complete the [Installation](#installation) and [Core Inte
 - iOS 17.0 or higher
 - Camera permission
 - Photo Library permission
+- NFC capability (required for passport reading)
 
 Add the following keys to your `Info.plist`:
 
@@ -38,7 +39,24 @@ Add the following keys to your `Info.plist`:
 <string>Photo library access is required to store captured images</string>
 <key>NSPhotoLibraryAddUsageDescription</key>
 <string>Photo library access is required to store captured images</string>
+<key>NFCReaderUsageDescription</key>
+<string>Used to read NFC chip data from your passport for identity verification.</string>
+<key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
+<array>
+    <string>A0000002471001</string>
+</array>
 ```
+
+Enable the **Near Field Communication Tag Reading** capability in your target's *Signing & Capabilities* tab. Xcode will add the following to your `.entitlements` file:
+
+```xml
+<key>com.apple.developer.nfc.readersession.formats</key>
+<array>
+    <string>TAG</string>
+</array>
+```
+
+> **About `A0000002471001`:** this is the ICAO 9303 ePassport Application Identifier (AID) — a fixed standard value used by all ePassport chips worldwide. Copy it verbatim; it is not application-specific.
 
 ## Installation
 


### PR DESCRIPTION
Aligns install docs with the v12.0.0 sdk-static-deps end state.

**Android (`onboard_id_android.md`):**
- Remove `https://art.myverify.io/netki/libs-release-local/` from Maven repositories — netkicv is now bundled inside the published `com.netki:netkisdk:12.0.0` AAR.
- Bump minSdk to 23.

**iOS (`onboard_id_ios.md`):**
- Bump deployment target 13.0 → 17.0.
- Document the NFC `Info.plist` keys + entitlements consumer apps need for passport reading (`NFCReaderUsageDescription`, `com.apple.developer.nfc.readersession.iso7816.select-identifiers` with the ICAO ePassport AID `A0000002471001`, and the Xcode "Near Field Communication Tag Reading" capability which emits `com.apple.developer.nfc.readersession.formats`).