### PR TITLE
docs: Flutter v12 + NFC Developer Portal enablement (iOS + Flutter)

### DIFF
--- a/onboard_id_flutter.md
+++ b/onboard_id_flutter.md
@@ -29,10 +29,11 @@ To get up and running, complete the [Installation](#installation) and [Core Inte
 - Dart SDK 3.11.1 or higher
 - iOS 17.0 or higher
 - Android API level 24 (Android 7.0) or higher
+- NFC capability (required for passport reading)
 
 ### iOS Setup
 
-Add the following keys to your `Info.plist`:
+Add the following keys to your `ios/Runner/Info.plist`:
 
 ```xml
 <key>NSCameraUsageDescription</key>
@@ -41,7 +42,24 @@ Add the following keys to your `Info.plist`:
 <string>Photo library access is required to store captured images</string>
 <key>NSPhotoLibraryAddUsageDescription</key>
 <string>Photo library access is required to store captured images</string>
+<key>NFCReaderUsageDescription</key>
+<string>Used to read NFC chip data from your passport for identity verification.</string>
+<key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
+<array>
+    <string>A0000002471001</string>
+</array>
 ```
+
+Enable the **Near Field Communication Tag Reading** capability in your Xcode project's *Signing & Capabilities* tab. Xcode will add the following to your `Runner.entitlements` file:
+
+```xml
+<key>com.apple.developer.nfc.readersession.formats</key>
+<array>
+    <string>TAG</string>
+</array>
+```
+
+> **About `A0000002471001`:** this is the ICAO 9303 ePassport Application Identifier (AID) — a fixed standard value used by all ePassport chips worldwide. Copy it verbatim; it is not application-specific.
 
 ### Android Setup
 
@@ -60,7 +78,7 @@ In your `pubspec.yaml`, add the Netki SDK:
 
 ```yaml
 dependencies:
-  netki_sdk: ^${latest.version}
+  netki_sdk: ^12.0.0
 ```
 
 Then run:
@@ -69,7 +87,7 @@ Then run:
 flutter pub get
 ```
 
-> **TODO:** Package repository URL to be defined once published to production.
+Available at [pub.dev/packages/netki_sdk](https://pub.dev/packages/netki_sdk).
 
 ### Step 2: Import the SDK
 

--- a/onboard_id_flutter.md
+++ b/onboard_id_flutter.md
@@ -61,6 +61,19 @@ Enable the **Near Field Communication Tag Reading** capability in your Xcode pro
 
 > **About `A0000002471001`:** this is the ICAO 9303 ePassport Application Identifier (AID) — a fixed standard value used by all ePassport chips worldwide. Copy it verbatim; it is not application-specific.
 
+#### Enable NFC on your App ID in Apple Developer Portal
+
+Info.plist keys and entitlements alone are not enough — the App ID itself must have the NFC capability enabled in the Apple Developer Portal, otherwise provisioning strips the entitlement and `NFCTagReaderSession.readingAvailable` returns `false` at runtime.
+
+1. Sign in at [developer.apple.com/account](https://developer.apple.com/account).
+2. Left nav → **Certificates, Identifiers & Profiles** → **Identifiers**.
+3. Filter to **App IDs** and open the App ID matching your app's bundle identifier.
+4. In the **Capabilities** list, tick **NFC Tag Reading** and click **Save**.
+5. Enabling the capability invalidates existing provisioning profiles. Go to **Profiles**, filter to that bundle ID, and click **Edit → Save** on each affected profile so Apple re-issues them with the new entitlement.
+6. In Xcode: Settings → Accounts → your Apple ID → **Download Manual Profiles** (or let automatic signing re-fetch on next build).
+
+Repeat for every build configuration whose bundle ID differs (Development / QA / Production typically have three separate App IDs — enable NFC on each).
+
 ### Android Setup
 
 Add the following permissions to your `AndroidManifest.xml`:

--- a/onboard_id_ios.md
+++ b/onboard_id_ios.md
@@ -58,6 +58,19 @@ Enable the **Near Field Communication Tag Reading** capability in your target's 
 
 > **About `A0000002471001`:** this is the ICAO 9303 ePassport Application Identifier (AID) — a fixed standard value used by all ePassport chips worldwide. Copy it verbatim; it is not application-specific.
 
+### Enable NFC on your App ID in Apple Developer Portal
+
+Info.plist keys and entitlements alone are not enough — the App ID itself must have the NFC capability enabled in the Apple Developer Portal, otherwise provisioning strips the entitlement and `NFCTagReaderSession.readingAvailable` returns `false` at runtime.
+
+1. Sign in at [developer.apple.com/account](https://developer.apple.com/account).
+2. Left nav → **Certificates, Identifiers & Profiles** → **Identifiers**.
+3. Filter to **App IDs** and open the App ID matching your app's bundle identifier.
+4. In the **Capabilities** list, tick **NFC Tag Reading** and click **Save**.
+5. Enabling the capability invalidates existing provisioning profiles. Go to **Profiles**, filter to that bundle ID, and click **Edit → Save** on each affected profile so Apple re-issues them with the new entitlement.
+6. In Xcode: Settings → Accounts → your Apple ID → **Download Manual Profiles** (or let automatic signing re-fetch on next build).
+
+Repeat for every build configuration whose bundle ID differs (Development / QA / Production typically have three separate App IDs — enable NFC on each).
+
 ## Installation
 
 ### Step 1: Add the Dependency


### PR DESCRIPTION
Two things:

1. Flutter (`onboard_id_flutter.md`) — companion to onboardid-flutter#26. NFC entitlements section, resolves pub.dev URL TODO with `^12.0.0`.

2. Developer Portal enablement (`onboard_id_ios.md` + `onboard_id_flutter.md`) — surfaced today while testing v12 against DEV: even with Info.plist + entitlements + Xcode capability, NFC still fails at runtime unless the App ID itself has the **NFC Tag Reading** capability enabled in Apple Developer Portal. Added a step-by-step block covering portal enablement + profile regeneration, per-bundle-id. Applies to all iOS-integrated consumers regardless of build config.